### PR TITLE
Upload replace fix

### DIFF
--- a/postgresql_blueprints/execute_sql.py
+++ b/postgresql_blueprints/execute_sql.py
@@ -60,6 +60,7 @@ def create_db_connection(db_string):
     if 'db.bit.io' in db_string:
         db_connection = create_engine(
             db_string,
+            connect_args={'sslmode': 'require'},
             isolation_level='AUTOCOMMIT')
     else:
         db_connection = create_engine(

--- a/postgresql_blueprints/store_query_results.py
+++ b/postgresql_blueprints/store_query_results.py
@@ -114,6 +114,7 @@ def create_db_connection(db_string):
     if 'db.bit.io' in db_string:
         db_connection = create_engine(
             db_string,
+            connect_args={'sslmode': 'require'},
             isolation_level='AUTOCOMMIT')
     else:
         db_connection = create_engine(

--- a/postgresql_blueprints/upload_file.py
+++ b/postgresql_blueprints/upload_file.py
@@ -145,7 +145,7 @@ def upload_data(
         schema):
 
     upload_method = determine_upload_method(db_connection)
-    if os.path.getsize(source_full_path) < 5000000:
+    if os.path.getsize(source_full_path) < 50000000:
         # Avoid chunksize if the file is small, since this is faster.
         df = pd.read_csv(source_full_path)
         df.to_sql(

--- a/postgresql_blueprints/upload_file.py
+++ b/postgresql_blueprints/upload_file.py
@@ -128,6 +128,15 @@ def combine_folder_and_file_name(folder_name, file_name):
     return combined_name
 
 
+def determine_upload_method(db_connection):
+    if 'db.bit.io' in str(db_connection):
+        upload_method = bitio_upload_method
+    else:
+        upload_method = 'multi'
+
+    return upload_method
+
+
 def upload_data(
         source_full_path,
         table_name,
@@ -135,53 +144,42 @@ def upload_data(
         db_connection,
         schema):
 
-    if 'db.bit.io' in str(db_connection):
-        if os.path.getsize(source_full_path) < 250000000:
-            # Avoid chunksize if the file is small, since this is faster.
-            df = pd.read_csv(source_full_path)
-            df.to_sql(
-                table_name,
-                con=db_connection,
-                index=False,
-                if_exists=insert_method,
-                method=bitio_upload_method,
-                schema=schema)
-        else:
-            # Resort to chunks for larger files to avoid memory issues.
-            for index, chunk in enumerate(
-                    pd.read_csv(source_full_path, chunksize=10000)):
-
-                if insert_method == 'replace' and index > 0:
-                    # When using the bitio_upload_method, replace results
-                    # in each chunk replacing the last. This makes sure
-                    # the first chunk replaces, the rest append.
-                    chunk.to_sql(
-                        table_name,
-                        con=db_connection,
-                        index=False,
-                        if_exists='append',
-                        method=bitio_upload_method,
-                        chunksize=10000,
-                        schema=schema)
-                else:
-                    chunk.to_sql(
-                        table_name,
-                        con=db_connection,
-                        index=False,
-                        if_exists=insert_method,
-                        method=bitio_upload_method,
-                        chunksize=10000,
-                        schema=schema)
+    upload_method = determine_upload_method(db_connection)
+    if os.path.getsize(source_full_path) < 5000000:
+        # Avoid chunksize if the file is small, since this is faster.
+        df = pd.read_csv(source_full_path)
+        df.to_sql(
+            table_name,
+            con=db_connection,
+            index=False,
+            if_exists=insert_method,
+            method=upload_method,
+            schema=schema)
     else:
-        for chunk in pd.read_csv(source_full_path, chunksize=10000):
-            chunk.to_sql(
-                table_name,
-                con=db_connection,
-                index=False,
-                if_exists=insert_method,
-                method='multi',
-                chunksize=10000,
-                schema=schema)
+        # Resort to chunks for larger files to avoid memory issues.
+        for index, chunk in enumerate(
+                pd.read_csv(source_full_path, chunksize=10000)):
+
+            if insert_method == 'replace' and index > 0:
+                # First chunk replaces the table, the following chunks
+                # append to the end.
+                chunk.to_sql(
+                    table_name,
+                    con=db_connection,
+                    index=False,
+                    if_exists='append',
+                    method=upload_method,
+                    chunksize=10000,
+                    schema=schema)
+            else:
+                chunk.to_sql(
+                    table_name,
+                    con=db_connection,
+                    index=False,
+                    if_exists=insert_method,
+                    method=upload_method,
+                    chunksize=10000,
+                    schema=schema)
     print(f'{source_full_path} successfully uploaded to {table_name}.')
 
 
@@ -266,6 +264,8 @@ def main():
             db_connection=db_connection,
             schema=schema)
     db_connection.dispose()
+    executionTime = (time.time() - startTime)
+    print('Execution time in seconds: ' + str(executionTime))
 
 
 if __name__ == '__main__':

--- a/postgresql_blueprints/upload_file.py
+++ b/postgresql_blueprints/upload_file.py
@@ -187,6 +187,7 @@ def create_db_connection(db_string):
     if 'db.bit.io' in db_string:
         db_connection = create_engine(
             db_string,
+            connect_args={'sslmode': 'require'},
             isolation_level='AUTOCOMMIT')
     else:
         db_connection = create_engine(
@@ -264,8 +265,6 @@ def main():
             db_connection=db_connection,
             schema=schema)
     db_connection.dispose()
-    executionTime = (time.time() - startTime)
-    print('Execution time in seconds: ' + str(executionTime))
 
 
 if __name__ == '__main__':

--- a/postgresql_blueprints/upload_file.py
+++ b/postgresql_blueprints/upload_file.py
@@ -163,23 +163,16 @@ def upload_data(
             if insert_method == 'replace' and index > 0:
                 # First chunk replaces the table, the following chunks
                 # append to the end.
-                chunk.to_sql(
-                    table_name,
-                    con=db_connection,
-                    index=False,
-                    if_exists='append',
-                    method=upload_method,
-                    chunksize=10000,
-                    schema=schema)
-            else:
-                chunk.to_sql(
-                    table_name,
-                    con=db_connection,
-                    index=False,
-                    if_exists=insert_method,
-                    method=upload_method,
-                    chunksize=10000,
-                    schema=schema)
+                insert_method = 'append'
+
+            chunk.to_sql(
+                table_name,
+                con=db_connection,
+                index=False,
+                if_exists=insert_method,
+                method=upload_method,
+                chunksize=10000,
+                schema=schema)
     print(f'{source_full_path} successfully uploaded to {table_name}.')
 
 


### PR DESCRIPTION
- Fix logic so that "replace" method first replaces, then appends.
- Updated bit.io to abide by new SSL requirements
- Decrease definition of "Small file size" to 50mb (to avoid potential memory issues)